### PR TITLE
Add Gitlab CICD templates

### DIFF
--- a/devops-integrations/gitlab/debricked-sca.yml
+++ b/devops-integrations/gitlab/debricked-sca.yml
@@ -1,0 +1,14 @@
+# Integrate Debricked software composition analysis into your Gitlab CICD pipeline
+# The following Gitlab environment variables must be defined before using this job
+#   - $DEBRICKED_TOKEN
+
+debricked-sca:
+  stage: test
+  image:
+    name: debricked/debricked-scan
+    entrypoint: ["/gitlab-ci.sh"]
+  script: echo "Debricked scan complete."
+  needs: [build]
+  variables:
+    DEBRICKED_TOKEN: $DEBRICKED_TOKEN
+  allow_failure: true

--- a/devops-integrations/gitlab/fortify-dast-scancentral.yml
+++ b/devops-integrations/gitlab/fortify-dast-scancentral.yml
@@ -11,7 +11,7 @@ fortify-dast:
   stage: test
   needs: [deploy]
   variables:
-    SC_DAST_SCAN_NAME: "IWA-Java-Gitlab-UI"
+    SC_DAST_SCAN_NAME: "IWA-Java"
   script:
     - fcli ssc session login 
     - fcli sc-dast session login

--- a/devops-integrations/gitlab/fortify-dast-scancentral.yml
+++ b/devops-integrations/gitlab/fortify-dast-scancentral.yml
@@ -15,19 +15,12 @@ fortify-dast:
   script:
     - fcli ssc session login 
     - fcli sc-dast session login
-
-    # Run DAST scan. Note that we don't have commands yet for configuring a scan for a particular
-    # application version, so results will be published to the application version associated with
-    # the given CICDToken
+    
     - fcli sc-dast scan start $SC_DAST_SCAN_NAME --settings $SC_DAST_SETTINGS --store '?'
-
-    # Wait for both DAST scan to complete
     - fcli sc-dast scan wait-for '?' -i 30s
-
-    # Run FortifyVulnerabilityExporter;
+    
     - FortifyVulnerabilityExporter SSCToGitLabDAST --ssc.baseUrl=$FCLI_SSC_URL --ssc.user="$FCLI_SSC_USER" --ssc.password="$FCLI_SSC_PASSWORD" --ssc.version.id=$SSC_AV_ID
-
-    # Clean up tokens, session variables, ...
+    
     - fcli sc-dast session logout
     - fcli ssc session logout
   artifacts:

--- a/devops-integrations/gitlab/fortify-dast-scancentral.yml
+++ b/devops-integrations/gitlab/fortify-dast-scancentral.yml
@@ -1,0 +1,37 @@
+# Integrate Fortify ScanCentral Dynamic AppSec Testing (DAST) into your Gitlab CICD pipeline
+# The following Gitlab environment variables must be defined before using this job
+#   - $FCLI_SSC_URL
+#   - $FCLI_SSC_USER
+#   - $FCLI_SSC_PASSWORD
+#   - $SC_DAST_SETTINGS
+#   - $SSC_AV_ID
+
+fortify-dast:
+  image: rsenden/fortify-ci-tools:fcli-beta
+  stage: test
+  needs: [deploy]
+  variables:
+    SC_DAST_SCAN_NAME: "IWA-Java-Gitlab-UI"
+  script:
+    - fcli ssc session login 
+    - fcli sc-dast session login
+
+    # Run DAST scan. Note that we don't have commands yet for configuring a scan for a particular
+    # application version, so results will be published to the application version associated with
+    # the given CICDToken
+    - fcli sc-dast scan start $SC_DAST_SCAN_NAME --settings $SC_DAST_SETTINGS --store '?'
+
+    # Wait for both DAST scan to complete
+    - fcli sc-dast scan wait-for '?' -i 30s
+
+    # Run FortifyVulnerabilityExporter;
+    - FortifyVulnerabilityExporter SSCToGitLabDAST --ssc.baseUrl=$FCLI_SSC_URL --ssc.user="$FCLI_SSC_USER" --ssc.password="$FCLI_SSC_PASSWORD" --ssc.version.id=$SSC_AV_ID
+
+    # Clean up tokens, session variables, ...
+    - fcli sc-dast session logout
+    - fcli ssc session logout
+  artifacts:
+    reports:
+      dast: gl-fortify-dast.json
+    expire_in: 3 days
+    when: always

--- a/devops-integrations/gitlab/fortify-sast-fod.yml
+++ b/devops-integrations/gitlab/fortify-sast-fod.yml
@@ -13,12 +13,10 @@ fortify-sast:
     FOD_API_URL: "https://api.ams.fortify.com/"
     FOD_UPLOADER_OPTS: "-ep 2 -pp 0 -I 1 -apf"
     FOD_NOTES: "Triggered by Gitlab Pipeline IID $CI_PIPELINE_IID: $CI_PIPELINE_URL"
-
   script:
     - scancentral package -bt mvn -oss -o package.zip
     - FoDUpload -z package.zip -aurl $FOD_API_URL -purl $FOD_URL -rid "$FOD_RELEASE_ID" -tc "$FOD_TENANT" -uc "$FOD_USER" "$FOD_PAT" $FOD_UPLOADER_OPTS -n "$FOD_NOTES"
     - FortifyVulnerabilityExporter FoDToGitLabSAST --fod.baseUrl=$FOD_URL --fod.tenant="$FOD_TENANT" --fod.userName="$FOD_USER" --fod.password="$FOD_PAT" --fod.release.id=$FOD_RELEASE_ID
-
   allow_failure: true
   artifacts:
     reports:

--- a/devops-integrations/gitlab/fortify-sast-fod.yml
+++ b/devops-integrations/gitlab/fortify-sast-fod.yml
@@ -1,0 +1,27 @@
+# Integrate Fortify ScanCentral Dynamic AppSec Testing (DAST) into your Gitlab CICD pipeline
+# The following Gitlab environment variables must be defined before using this job
+#   - $FOD_RELEASE_ID
+#   - $FOD_USER
+#   - $FOD_PAT
+#   - $FOD_TENANT
+
+fortify-sast:
+  image: fortifydocker/fortify-ci-tools:3-jdk-11
+  stage: test
+  variables:
+    FOD_URL: "https://ams.fortify.com"
+    FOD_API_URL: "https://api.ams.fortify.com/"
+    FOD_UPLOADER_OPTS: "-ep 2 -pp 0 -I 1 -apf"
+    FOD_NOTES: "Triggered by Gitlab Pipeline IID $CI_PIPELINE_IID: $CI_PIPELINE_URL"
+
+  script:
+    - scancentral package -bt mvn -oss -o package.zip
+    - FoDUpload -z package.zip -aurl $FOD_API_URL -purl $FOD_URL -rid "$FOD_RELEASE_ID" -tc "$FOD_TENANT" -uc "$FOD_USER" "$FOD_PAT" $FOD_UPLOADER_OPTS -n "$FOD_NOTES"
+    - FortifyVulnerabilityExporter FoDToGitLabSAST --fod.baseUrl=$FOD_URL --fod.tenant="$FOD_TENANT" --fod.userName="$FOD_USER" --fod.password="$FOD_PAT" --fod.release.id=$FOD_RELEASE_ID
+
+  allow_failure: true
+  artifacts:
+    reports:
+      sast: gl-fortify-sast.json
+    expire_in: 3 days
+    when: always

--- a/devops-integrations/gitlab/fortify-sast-scancentral.yml
+++ b/devops-integrations/gitlab/fortify-sast-scancentral.yml
@@ -1,0 +1,39 @@
+# Integrate Fortify ScanCentral Static AppSec Testing (SAST) into your Gitlab CICD pipeline
+# The following Gitlab environment variables must be defined before using this job
+#   - $FCLI_SSC_URL
+#   - $FCLI_SSC_USER
+#   - $FCLI_SSC_PASSWORD
+#   - $FCLI_SC_SAST_CLIENT_AUTH_TOKEN
+#   - $FCLI_SC_SAST_SCAN_CI_TOKEN
+#   - $FCLI_SSC_CITOKEN
+#   - $SSC_AV_ID
+
+fortify-sast:
+  stage: test
+  image: rsenden/fortify-ci-tools:fcli-beta
+  needs: [build]
+  variables:
+    SC_SAST_SENSOR_VERSION: '22.2'
+  script:
+    - fcli ssc session login
+    - fcli sc-sast session login
+
+    # Package sources & run SAST scan
+    - scancentral package -bt mvn -o package.zip 
+    - fcli sc-sast scan start package package.zip --sensor-version=$SC_SAST_SENSOR_VERSION --appversion=$SSC_AV_ID --store '?'
+
+    # Wait for SAST scan to complete
+    - fcli sc-sast scan wait-for-artifact '?' -i 30s
+
+    # Run FortifyVulnerabilityExporter to upload results
+    - FortifyVulnerabilityExporter SSCToGitLabSAST --ssc.baseUrl=$FCLI_SSC_URL --ssc.user="$FCLI_SSC_USER" --ssc.password="$FCLI_SSC_PASSWORD" --ssc.version.id=$SSC_AV_ID
+
+    # Clean up tokens, session variables, ...
+    - fcli sc-sast session logout
+    - fcli ssc session logout  
+  allow_failure: true
+  artifacts:
+    reports:
+      sast: gl-fortify-sast.json
+    expire_in: 3 days
+    when: always

--- a/devops-integrations/gitlab/fortify-sast-scancentral.yml
+++ b/devops-integrations/gitlab/fortify-sast-scancentral.yml
@@ -18,17 +18,13 @@ fortify-sast:
     - fcli ssc session login
     - fcli sc-sast session login
 
-    # Package sources & run SAST scan
     - scancentral package -bt mvn -o package.zip 
     - fcli sc-sast scan start package package.zip --sensor-version=$SC_SAST_SENSOR_VERSION --appversion=$SSC_AV_ID --store '?'
 
-    # Wait for SAST scan to complete
     - fcli sc-sast scan wait-for-artifact '?' -i 30s
 
-    # Run FortifyVulnerabilityExporter to upload results
     - FortifyVulnerabilityExporter SSCToGitLabSAST --ssc.baseUrl=$FCLI_SSC_URL --ssc.user="$FCLI_SSC_USER" --ssc.password="$FCLI_SSC_PASSWORD" --ssc.version.id=$SSC_AV_ID
 
-    # Clean up tokens, session variables, ...
     - fcli sc-sast session logout
     - fcli ssc session logout  
   allow_failure: true

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -1,0 +1,33 @@
+include:
+  - local: '/devops-integrations/gitlab/debricked-sca.yml'
+  - local: '/devops-integrations/gitlab/fortify-sast-scancentral.yml'
+  - local: '/devops-integrations/gitlab/fortify-dast-scancentral.yml'
+
+stages:
+  - build
+  - deploy
+  - test
+
+build:
+  stage: build
+  image: maven:3.8.6-eclipse-temurin-8
+
+  script: 
+    - echo Building project...
+    - mvn -Pjar clean package
+    - mvn dependency:tree
+        -DoutputFile=.debricked-maven-dependencies.tgf
+        -DoutputType=tgf
+  when: manual
+  artifacts:
+    paths:
+    - .debricked-maven-dependencies.tgf
+    - /
+    expire_in: 3 days
+    when: on_success
+
+deploy:
+  stage: deploy
+  needs: [build]
+  script:
+    - echo 'Simulating deployment of application...'

--- a/gitlab-ci.yml
+++ b/gitlab-ci.yml
@@ -2,7 +2,8 @@ include:
   - local: '/devops-integrations/gitlab/debricked-sca.yml'
   - local: '/devops-integrations/gitlab/fortify-sast-scancentral.yml'
   - local: '/devops-integrations/gitlab/fortify-dast-scancentral.yml'
-
+  #- local: '/devops-integrations/gitlab/fortify-sast-fod.yml'
+  
 stages:
   - build
   - deploy


### PR DESCRIPTION
Includes templates for SAST (ScanCentral, Fortify on Demand), DAST (ScanCentral), SCA (Debricked).  ScanCentral SAST, ScanCentral DAST and Debricked SCA enabled by default.