### PR TITLE
update env variables back to FCLI_DEFAULT

### DIFF
--- a/devops-integrations/gitlab/fortify-sast-scancentral.yml
+++ b/devops-integrations/gitlab/fortify-sast-scancentral.yml
@@ -3,8 +3,8 @@
 #   - $FCLI_DEFAULT_SC_SAST_CLIENT_AUTH_TOKEN
 #   - $FCLI_DEFAULT_SSC_CI_TOKEN
 #   - $FCLI_DEFAULT_SSC_URL
-#   - $SSC_USER
-#   - $SSC_PASSWORD
+#   - $FCLI_DEFAULT_SSC_USER
+#   - $FCLI_DEFAULT_SSC_PASSWORD
 #   - $SSC_AV_ID
 
 fortify-sast:
@@ -22,7 +22,7 @@ fortify-sast:
 
     - fcli sc-sast scan wait-for '?' --interval=30s
 
-    - FortifyVulnerabilityExporter SSCToGitLabSAST --ssc.baseUrl=$FCLI_DEFAULT_SSC_URL --ssc.user="$SSC_USER" --ssc.password="$SSC_PASSWORD" --ssc.version.id=$SSC_AV_ID
+    - FortifyVulnerabilityExporter SSCToGitLabSAST --ssc.baseUrl=$FCLI_DEFAULT_SSC_URL --ssc.user="$FCLI_DEFAULT_SSC_USER" --ssc.password="$FCLI_DEFAULT_SSC_PASSWORD" --ssc.version.id=$SSC_AV_ID
 
     - fcli sc-sast session logout
     - fcli ssc session logout  


### PR DESCRIPTION
Change the SSC_USER to FCLI_DEFAULT_SSC_USER and SSC_PASSWORD to FCLI_DEFAULT_SSC_PASSWORD as fcli session logout requires username and password