### PR TITLE
Add support for Mobile client access via API.

### DIFF
--- a/src/main/java/com/microfocus/example/api/controllers/ApiProductController.java
+++ b/src/main/java/com/microfocus/example/api/controllers/ApiProductController.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2021 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/api/controllers/ApiProductController.java
+++ b/src/main/java/com/microfocus/example/api/controllers/ApiProductController.java
@@ -19,10 +19,10 @@
 
 package com.microfocus.example.api.controllers;
 
-import com.microfocus.example.payload.request.ProductRequest;
-import com.microfocus.example.payload.response.ApiStatusResponse;
 import com.microfocus.example.entity.Product;
 import com.microfocus.example.exception.ProductNotFoundException;
+import com.microfocus.example.payload.request.ProductRequest;
+import com.microfocus.example.payload.response.ApiStatusResponse;
 import com.microfocus.example.payload.response.ProductResponse;
 import com.microfocus.example.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,13 +33,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;import org.slf4j.LoggerFactory;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -181,6 +185,34 @@ public class ApiProductController {
                 .atTime(LocalDateTime.now(ZoneOffset.UTC))
                 .build();
         return new ResponseEntity<>(apiStatusResponse, HttpStatus.OK);
+    }
+
+
+    @Operation(summary = "Get product image by Id", description = "Get a product's image by its UUID", tags = {"products"}, security = @SecurityRequirement(name = "JWT Authentication"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success", content = @Content(schema = @Schema(implementation = ProductResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ApiStatusResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ApiStatusResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ApiStatusResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Product Not Found", content = @Content(schema = @Schema(implementation = ApiStatusResponse.class))),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(schema = @Schema(implementation = ApiStatusResponse.class))),
+    })
+    @GetMapping(value = {"/{id}/image"}, produces =  {"application/json"})
+    public ResponseEntity<InputStreamResource> findProductImageById(
+            @Parameter(description = "UUID of the product. Cannot be empty.", example = "eec467c8-5de9-4c7c-8541-7b31614d31a0", required = true) @PathVariable("id") UUID id) {
+        log.debug("API::Retrieving product image for UUID: " + id);
+        if (!productService.productExistsById(id))
+            throw new ProductNotFoundException("Product with UUID: " + id.toString() + " does not exist.");
+        Optional<Product> product = productService.findProductById(id);
+        MediaType contentType = MediaType.IMAGE_JPEG;
+        InputStream in = getClass().getResourceAsStream("/static/img/products/"+product.get().getImage());
+        if (in == null) {
+            log.error("Could not find resource /static/img/products/{}", product.get().getImage());
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok()
+                .contentType(contentType)
+                .body(new InputStreamResource(in));
     }
 
 }

--- a/src/main/java/com/microfocus/example/api/controllers/ApiSiteController.java
+++ b/src/main/java/com/microfocus/example/api/controllers/ApiSiteController.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2021 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/config/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/microfocus/example/config/handlers/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2020-2022 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/config/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/microfocus/example/config/handlers/GlobalExceptionHandler.java
@@ -19,6 +19,8 @@
 
 package com.microfocus.example.config.handlers;
 
+import com.microfocus.example.exception.ApiBadCredentialsException;
+import com.microfocus.example.exception.ApiRefreshTokenException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +51,34 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     public static final String DEFAULT_ERROR_VIEW = "error/default";
     public static final String SERVER_ERROR_VIEW = "error/500-internal-error";
+
+    @ExceptionHandler(ApiBadCredentialsException.class)
+    public ResponseEntity<ApiStatusResponse> badCredentials(final ApiBadCredentialsException ex, final WebRequest request) {
+        log.debug("GlobalExceptionHandler::badCredentials");
+        ArrayList<String> errors = new ArrayList<>();
+        errors.add(ex.getLocalizedMessage());
+        final ApiStatusResponse apiStatusResponse = new ApiStatusResponse
+                .ApiResponseBuilder()
+                .withSuccess(false)
+                .atTime(LocalDateTime.now(ZoneOffset.UTC))
+                .withErrors(errors)
+                .build();
+        return new ResponseEntity<ApiStatusResponse>(apiStatusResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ApiRefreshTokenException.class)
+    public ResponseEntity<ApiStatusResponse> refreshToken(final ApiRefreshTokenException ex, final WebRequest request) {
+        log.debug("GlobalExceptionHandler::refreshToken");
+        ArrayList<String> errors = new ArrayList<>();
+        errors.add(ex.getLocalizedMessage());
+        final ApiStatusResponse apiStatusResponse = new ApiStatusResponse
+                .ApiResponseBuilder()
+                .withSuccess(false)
+                .atTime(LocalDateTime.now(ZoneOffset.UTC))
+                .withErrors(errors)
+                .build();
+        return new ResponseEntity<ApiStatusResponse>(apiStatusResponse, HttpStatus.NOT_FOUND);
+    }
 
     @ExceptionHandler(ServerErrorException.class)
     public ModelAndView handleServerErrorException(final ServerErrorException ex, final HttpServletRequest request) {

--- a/src/main/java/com/microfocus/example/config/handlers/GlobalRestExceptionHandler.java
+++ b/src/main/java/com/microfocus/example/config/handlers/GlobalRestExceptionHandler.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2020-2022 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/config/handlers/GlobalRestExceptionHandler.java
+++ b/src/main/java/com/microfocus/example/config/handlers/GlobalRestExceptionHandler.java
@@ -19,11 +19,8 @@
 
 package com.microfocus.example.config.handlers;
 
+import com.microfocus.example.exception.*;
 import com.microfocus.example.payload.response.ApiStatusResponse;
-import com.microfocus.example.exception.MessageNotFoundException;
-import com.microfocus.example.exception.ProductNotFoundException;
-import com.microfocus.example.exception.RoleNotFoundException;
-import com.microfocus.example.exception.UserNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.TypeMismatchException;
@@ -47,7 +44,6 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import java.time.LocalDateTime;
@@ -63,6 +59,20 @@ public class GlobalRestExceptionHandler extends ResponseEntityExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(GlobalRestExceptionHandler.class);
 
     // Custom exception handlers
+
+    @ExceptionHandler(ApiBadCredentialsException.class)
+    public ResponseEntity<ApiStatusResponse> badCredentials(final ApiBadCredentialsException ex, final WebRequest request) {
+        log.debug("GlobalRestExceptionHandler::badCredentials");
+        ArrayList<String> errors = new ArrayList<>();
+        errors.add(ex.getLocalizedMessage());
+        final ApiStatusResponse apiStatusResponse = new ApiStatusResponse
+                .ApiResponseBuilder()
+                .withSuccess(false)
+                .atTime(LocalDateTime.now(ZoneOffset.UTC))
+                .withErrors(errors)
+                .build();
+        return new ResponseEntity<ApiStatusResponse>(apiStatusResponse, HttpStatus.NOT_FOUND);
+    }
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ApiStatusResponse> userNotFound(final UserNotFoundException ex, final WebRequest request) {

--- a/src/main/java/com/microfocus/example/entity/Authority.java
+++ b/src/main/java/com/microfocus/example/entity/Authority.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2020 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/entity/RefreshToken.java
+++ b/src/main/java/com/microfocus/example/entity/RefreshToken.java
@@ -1,0 +1,94 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.entity;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.microfocus.example.utils.JwtUtils;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A JWT refresh token.
+ *
+ * @author Kevin A. Lee
+ */
+@Entity
+@Table(name = "refresh_tokens")
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+public class RefreshToken implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(
+            name = "UUID",
+            strategy = "org.hibernate.id.UUIDGenerator"
+    )
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @Column(name = "expiry_date", nullable = false)
+    private Instant expiryDate;
+
+    public RefreshToken() {
+        JwtUtils jwtUtils = new JwtUtils();
+        this.expiryDate = jwtUtils.getDefaultExpiration();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return this.user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Instant getExpiryDate() {
+        return this.expiryDate;
+    }
+
+    public void setExpiryDate(Instant expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    @Override
+    public String toString() {
+        return "RefreshToken(" + id + " for: " + user.getUsername() + " expires on: " + expiryDate.toString() + ")";
+    }
+
+}

--- a/src/main/java/com/microfocus/example/entity/RefreshToken.java
+++ b/src/main/java/com/microfocus/example/entity/RefreshToken.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/exception/ApiBadCredentialsException.java
+++ b/src/main/java/com/microfocus/example/exception/ApiBadCredentialsException.java
@@ -1,0 +1,39 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Allow the controller to return a 404 if a user is not found by simply
+ * throwing this exception. The @ResponseStatus causes Spring MVC to return a
+ * 404 instead of the usual 500.
+ * @author Kevin A. Lee
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ApiBadCredentialsException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ApiBadCredentialsException(String username) {
+        super("Invalid credentials for username: " + username);
+    }
+}

--- a/src/main/java/com/microfocus/example/exception/ApiBadCredentialsException.java
+++ b/src/main/java/com/microfocus/example/exception/ApiBadCredentialsException.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/exception/ApiRefreshTokenException.java
+++ b/src/main/java/com/microfocus/example/exception/ApiRefreshTokenException.java
@@ -1,0 +1,33 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ApiRefreshTokenException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ApiRefreshTokenException(String token, String message) {
+        super(String.format("Failed for [%s]: %s", token, message));
+    }
+}

--- a/src/main/java/com/microfocus/example/exception/ApiRefreshTokenException.java
+++ b/src/main/java/com/microfocus/example/exception/ApiRefreshTokenException.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/payload/request/RefreshTokenRequest.java
+++ b/src/main/java/com/microfocus/example/payload/request/RefreshTokenRequest.java
@@ -1,0 +1,35 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.payload.request;
+
+import javax.validation.constraints.NotBlank;
+
+public class RefreshTokenRequest {
+    @NotBlank
+    private String refreshToken;
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/microfocus/example/payload/request/RefreshTokenRequest.java
+++ b/src/main/java/com/microfocus/example/payload/request/RefreshTokenRequest.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/payload/response/JwtResponse.java
+++ b/src/main/java/com/microfocus/example/payload/response/JwtResponse.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2020 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/payload/response/RefreshTokenResponse.java
+++ b/src/main/java/com/microfocus/example/payload/response/RefreshTokenResponse.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/payload/response/RefreshTokenResponse.java
+++ b/src/main/java/com/microfocus/example/payload/response/RefreshTokenResponse.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2020 Micro Focus or one of its affiliates
+        Copyright (C) 2023 Micro Focus or one of its affiliates
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,27 +19,16 @@
 
 package com.microfocus.example.payload.response;
 
-import java.util.List;
-import java.util.UUID;
-
-public class JwtResponse {
+public class RefreshTokenResponse {
     private String token;
     private String refreshToken;
-    private String type = "Bearer";
     private long expiration;
-    private UUID id;
-    private String username;
-    private String email;
-    private List<String> roles;
 
-    public JwtResponse(String accessToken, String refreshToken, long expiration, UUID id, String username, String email, List<String> roles) {
+
+    public RefreshTokenResponse(String accessToken, String refreshToken, long expiration) {
         this.token = accessToken;
         this.refreshToken = refreshToken;
         this.expiration = expiration;
-        this.id = id;
-        this.username = username;
-        this.email = email;
-        this.roles = roles;
     }
 
     public String getAccessToken() {
@@ -66,39 +55,4 @@ public class JwtResponse {
         this.expiration = expiration;
     }
 
-    public String getTokenType() {
-        return type;
-    }
-
-    public void setTokenType(String tokenType) {
-        this.type = tokenType;
-    }
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public List<String> getRoles() {
-        return roles;
-    }
 }

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepository.java
@@ -1,0 +1,28 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.repository;
+
+/**
+ * Interface for Refresh Token Repository
+ * @author Kevin A. Lee
+ */
+public interface RefreshTokenRepository extends RefreshTokenRepositoryBasic, RefreshTokenRepositoryCustom {
+
+}

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepository.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryBasic.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryBasic.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryBasic.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryBasic.java
@@ -1,0 +1,34 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.repository;
+
+import com.microfocus.example.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+/**
+ * Interface for Refresh Token Repository
+ *
+ * @author Kevin A. Lee
+ */
+public interface RefreshTokenRepositoryBasic extends JpaRepository<RefreshToken, UUID> {
+
+}

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryCustom.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryCustom.java
@@ -1,0 +1,34 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.repository;
+
+import com.microfocus.example.entity.User;
+import org.springframework.data.jpa.repository.Modifying;
+
+/**
+ * Interface for Refresh Token Repository
+ * @author Kevin A. Lee
+ */
+public interface RefreshTokenRepositoryCustom {
+
+    @Modifying
+    int deleteByUser(User user);
+
+}

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryCustom.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryCustom.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,58 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2020 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.repository;
+
+import com.microfocus.example.entity.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.transaction.Transactional;
+
+/**
+ * Implementation of Custom Refresh Token Repository
+ * @author Kevin A. Lee
+ */
+@Transactional
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepositoryCustom {
+
+    private static final Logger log = LoggerFactory.getLogger(RefreshTokenRepositoryImpl.class);
+
+    private final RefreshTokenRepositoryBasic refreshTokenRepositoryBasic;
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    public RefreshTokenRepositoryImpl(RefreshTokenRepositoryBasic refreshTokenRepositoryBasic) {
+        this.refreshTokenRepositoryBasic = refreshTokenRepositoryBasic;
+    }
+
+    @SuppressWarnings("unchecked")
+    public int deleteByUser(User user) {
+        Query query = entityManager.createQuery(
+                "DELETE FROM RefreshToken rt WHERE rt.user.id = ?1",
+                Long.class);
+        query.setParameter(1, user.getId());
+        return (int)(query.getFirstResult());
+    }
+
+}

--- a/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/microfocus/example/repository/RefreshTokenRepositoryImpl.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2020 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/service/RefreshTokenService.java
+++ b/src/main/java/com/microfocus/example/service/RefreshTokenService.java
@@ -1,0 +1,84 @@
+/*
+        Insecure Web App (IWA)
+
+        Copyright (C) 2023 Micro Focus or one of its affiliates
+
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.microfocus.example.service;
+
+import com.microfocus.example.entity.RefreshToken;
+import com.microfocus.example.exception.ApiRefreshTokenException;
+import com.microfocus.example.repository.RefreshTokenRepository;
+import com.microfocus.example.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Refresh Token Service to hide business logic / database persistence for Refresh Tokens
+ * @author Kevin A. Lee
+ */
+@Service
+@Transactional
+public class RefreshTokenService {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final String SERVICE_NAME = getClass().getName();
+
+    @Value("${app.jwt.refresh-ms}")
+    private int jwtRefreshMs;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findById(UUID.fromString(token));
+    }
+
+    public RefreshToken createRefreshToken(UUID userId) {
+        RefreshToken refreshToken = new RefreshToken();
+
+        refreshToken.setUser(userRepository.findById(userId).get());
+        refreshToken.setExpiryDate(Instant.now().plusMillis(jwtRefreshMs));
+        refreshToken.setId(UUID.randomUUID());
+
+        refreshToken = refreshTokenRepository.save(refreshToken);
+        return refreshToken;
+    }
+
+    public RefreshToken verifyExpiration(RefreshToken refreshToken) {
+        if (refreshToken.getExpiryDate().compareTo(Instant.now()) < 0) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new ApiRefreshTokenException(refreshToken.getId().toString(), "Refresh token is expired - please sign-in again!");
+        }
+
+        return refreshToken;
+    }
+
+    public int deleteByUserId(UUID userId) {
+        return refreshTokenRepository.deleteByUser((userRepository.findById(userId).get()));
+    }
+}

--- a/src/main/java/com/microfocus/example/service/RefreshTokenService.java
+++ b/src/main/java/com/microfocus/example/service/RefreshTokenService.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2023 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/microfocus/example/utils/JwtUtils.java
+++ b/src/main/java/com/microfocus/example/utils/JwtUtils.java
@@ -1,7 +1,7 @@
 /*
         Insecure Web App (IWA)
 
-        Copyright (C) 2020-2022 Micro Focus or one of its affiliates
+        Copyright 2020-2023 Open Text or one of its affiliates.
 
         This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -5,6 +5,7 @@
 --alter table orders drop constraint FKorders_user_id if exists;
 --alter table reviews drop constraint FKproducts_product_id if exists;
 --alter table reviews drop constraint FKproducts_user_id if exists;
+--alter table refresh_tokens constraint FK_refresh_tokens_user_id if exists;
 
 drop table authorities if exists cascade;
 drop table users if exists cascade;
@@ -14,6 +15,7 @@ drop table products if exists cascade;
 drop table messages if exists cascade;
 drop table orders if exists cascade;
 drop table reviews if exists cascade;
+drop table refresh_tokens if exists cascade;
 drop sequence if exists hibernate_sequence;
 create sequence hibernate_sequence start with 1 increment by 1;
 
@@ -107,6 +109,13 @@ create table reviews
     visible         bit(1)          not null,
     primary key (id)
 );
+create table refresh_tokens
+(
+    id              UUID            not null,
+    user_id         UUID            not null,
+    expiry_date     datetime        null,
+    primary key (id)
+);
 
 alter table users
     add constraint UKuser_username unique (username);
@@ -122,3 +131,5 @@ alter table reviews
     add constraint FKproducts_product_id foreign key (product_id) references products (id) on delete cascade;
 alter table reviews
     add constraint FKproducts_user_id foreign key (user_id) references users (id) on delete cascade;
+alter table refresh_tokens
+    add constraint FK_refresh_tokens_user_id foreign key (user_id) references users (id) on delete cascade;

--- a/src/test/java/com/microfocus/example/DataSeeder.java
+++ b/src/test/java/com/microfocus/example/DataSeeder.java
@@ -3,6 +3,7 @@ package com.microfocus.example;
 import com.microfocus.example.entity.*;
 import com.microfocus.example.utils.EncryptedPasswordUtils;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -73,6 +74,16 @@ public class DataSeeder {
     public static final UUID TEST_REVIEW1_USERID = UUID.fromString("bd5b9e2f-ac55-4e34-a76d-599b7e5b3308");
     public static final String TEST_REVIEW1_COMMENT = "This is an example review of Test Product 1. It is very good";
 
+    // Test Refresh Token:
+    // Refresh Token 1 - stored in database on startup
+    public static final UUID TEST_REFRESH_TOKEN1_ID = UUID.fromString("08b43d0d-2d86-4252-9782-10e73266d5c5");
+    public static final UUID TEST_REFRESH_TOKEN1_USERID = UUID.fromString("bd5b9e2f-ac55-4e34-a76d-599b7e5b3308");
+    public static final Instant TEST_REFRESH_TOKEN1_EXPIRY_DATE = Instant.now();
+    // Test Refresh Token 2 - created in tests
+    public static final UUID TEST_REFRESH_TOKEN2_ID = UUID.fromString("b8d2f683-fdfe-492e-86af-9df43a6b658b");
+    public static final UUID TEST_REFRESH_TOKEN2_USERID = UUID.fromString("bd5b9e2f-ac55-4e34-a76d-599b7e5b3308");
+    public static final Instant TEST_REFRESH_TOKEN2_EXPIRY_DATE = Instant.now();
+
     public static User generateUser() {
         User user = new User();
         user.setUsername(TEST_USER2_USERNAME);
@@ -106,6 +117,13 @@ public class DataSeeder {
         product.setRating(TEST_PRODUCT2_RATING);
         product.setAvailable(true);
         return product;
+    }
+
+    public static RefreshToken generateRefreshToken() {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setExpiryDate(TEST_REFRESH_TOKEN2_EXPIRY_DATE);
+        refreshToken.setId(TEST_REFRESH_TOKEN2_ID);
+        return refreshToken;
     }
 
     public static Authority generateAdminRole() {

--- a/src/test/java/com/microfocus/example/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/microfocus/example/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.microfocus.example.repository;
+
+import com.microfocus.example.BaseIntegrationTest;
+import com.microfocus.example.DataSeeder;
+import com.microfocus.example.entity.RefreshToken;
+import com.microfocus.example.entity.User;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class RefreshTokenRepositoryTest extends BaseIntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    public void a_refreshTokenRepository_existsById() {
+        if (!refreshTokenRepository.existsById(DataSeeder.TEST_REFRESH_TOKEN1_ID)) fail("Test Refresh Token 1 does not exist");
+    }
+
+    @Test
+    public void b_refreshTokenRepository_findById() {
+        Optional<RefreshToken> rt = refreshTokenRepository.findById(DataSeeder.TEST_REFRESH_TOKEN1_ID);
+        if (rt.isPresent())
+            assertThat(rt.get().getUser().getId()).isEqualTo(DataSeeder.TEST_REFRESH_TOKEN1_USERID);
+        else
+            fail("Test Refresh Token 1 not found");
+    }
+/*
+    @Test
+    public void c_refreshTokenRepository_findByUserId() {
+        List<RefreshToken> rts = refreshTokenRepository.findByUserId(DataSeeder.TEST_REFRESH_TOKEN1_ID);
+        assertThat(rts.size()).isEqualTo(1);
+    }
+*/
+    @Test
+    public void d_refreshTokenRepository_persist() {
+        RefreshToken rt = DataSeeder.generateRefreshToken();
+        Optional<User> u = userRepository.findById(DataSeeder.TEST_REFRESH_TOKEN2_USERID);
+        if (u.isPresent()) {
+            rt.setUser(u.get());
+        } else {
+            fail("Unable to retrieve user using id: " + DataSeeder.TEST_REFRESH_TOKEN2_USERID);
+        }
+        rt = refreshTokenRepository.saveAndFlush(rt);
+        Optional<RefreshToken> optRt = refreshTokenRepository.findById(rt.getId());
+        if (optRt.isPresent()) {
+            assertThat(optRt.get().getExpiryDate().equals(DataSeeder.TEST_REFRESH_TOKEN2_EXPIRY_DATE));
+        } else {
+            fail("Test Refresh Message 2 not found");
+        }
+    }
+
+    @Test
+    public void e_refreshTokenRepository_update() {
+        Optional<RefreshToken> optRt = refreshTokenRepository.findById(DataSeeder.TEST_REFRESH_TOKEN1_ID);
+        if (optRt.isPresent()) {
+            RefreshToken rt = optRt.get();
+            rt.setExpiryDate(DataSeeder.TEST_REFRESH_TOKEN1_EXPIRY_DATE.plusMillis(100000));
+            refreshTokenRepository.saveAndFlush(rt);
+            Optional<RefreshToken> optRt2 = refreshTokenRepository.findById(DataSeeder.TEST_REFRESH_TOKEN1_ID);
+            if (optRt.isPresent()) {
+                RefreshToken optRt3 = optRt.get();
+                assertThat(optRt3.getUser().getId()).isEqualTo(DataSeeder.TEST_REFRESH_TOKEN1_USERID);
+                assertThat(optRt3.getExpiryDate()).isEqualTo(DataSeeder.TEST_REFRESH_TOKEN1_EXPIRY_DATE.plusMillis(100000));
+            } else
+                fail("Test Refresh Token 1 not found");
+        } else
+            fail("Test Refresh Token 1 not found");
+    }
+
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -6,6 +6,7 @@ drop table products if exists cascade;
 drop table messages if exists cascade;
 drop table orders if exists cascade;
 drop table reviews if exists cascade;
+drop table refresh_tokens if exists cascade;
 drop sequence if exists hibernate_sequence;
 create sequence hibernate_sequence start with 1 increment by 1;
 
@@ -97,6 +98,13 @@ create table reviews
     visible         bit(1)          not null,
     primary key (id)
 );
+create table refresh_tokens
+(
+    id              UUID            not null,
+    user_id         UUID            not null,
+    expiry_date     datetime        null,
+    primary key (id)
+);
 
 alter table users
     add constraint UKuser_username unique (username);
@@ -112,3 +120,5 @@ alter table reviews
     add constraint FKproducts_product_id foreign key (product_id) references products (id) on delete cascade;
 alter table reviews
     add constraint FKproducts_user_id foreign key (user_id) references users (id) on delete cascade;
+alter table refresh_tokens
+    add constraint FK_refresh_tokens_user_id foreign key (user_id) references users (id) on delete cascade;


### PR DESCRIPTION
These changes update the API so a mobile client can be used to access the backend. This includes primarily adding a Refresh Token service, minor updates for sending REST message on failures (HTML was previously sent) as well as serving up product images.

An example React Native mobile client that makes use of this is here: [https://github.com/fortify-presales/IWA-Mobile](https://github.com/fortify-presales/IWA-Mobile) - needs a bit more work and Fortify does find some issues. Hopefully make a bit more progress and then we can host it here as well .

Kevin