### PR TITLE
Docs: Revise docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker build -t iwa -f Dockerfile.win .
 This image can then be executed using the following commands:
 
 ```
-docker run -d -p 8888:8888 iwa
+docker run -d -p 8888:8080 iwa
 ```
 
 ## Using the Application


### PR DESCRIPTION
This PR revises docker run command as it mapping wrong port (8888) as this image expose port 8080.

Refer to Dockerfile, this image expose port 8080:
https://github.com/fortify/IWA-Java/blob/29984490406bebbbdd57a388c057b3ec07a33299/Dockerfile#L9

In readme file, docker run mapping port 8888 instead of 8080:
https://github.com/fortify/IWA-Java/blob/29984490406bebbbdd57a388c057b3ec07a33299/README.md?plain=1#L68

The correct command to run this docker image is:
`docker run -d -p 8888:8080 iwa`

Noted that port 8888 can be changed to any port that not used by Docker host.