### PR TITLE
ci: update fortify/3rdparty-actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,7 +23,7 @@ jobs:
       run: mvn -Pjar clean package
 
     - name: Docker Login
-      uses: docker/login-action@v2
+      uses: fortify/3rdparty-actions/actions/docker/login-action/v3@main
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Update supported workflow actions to use the shared fortify/3rdparty-actions wrappers,